### PR TITLE
Bump deps to virgil-crypto-c 0.19.0-rc.13; re-enable SPM swift test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,12 +62,11 @@ jobs:
         env:
             ENCRYPTION_KEY: ${{ secrets.ENCRYPTION_KEY }}
             ENCRYPTION_IV: ${{ secrets.ENCRYPTION_IV }}
-      - name: SPM test
+      - name: SPM build
         run: |
             brew install coreutils
             swift --version
             timeout 15m bash -c 'until swift build; do rm -fr .build && sleep 10; done'
-            swift test
 
   Swiftlint:
     runs-on: macos-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,11 +62,12 @@ jobs:
         env:
             ENCRYPTION_KEY: ${{ secrets.ENCRYPTION_KEY }}
             ENCRYPTION_IV: ${{ secrets.ENCRYPTION_IV }}
-      - name: SPM build
+      - name: SPM test
         run: |
             brew install coreutils
             swift --version
             timeout 15m bash -c 'until swift build; do rm -fr .build && sleep 10; done'
+            swift test
 
   Swiftlint:
     runs-on: macos-latest

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/VirgilSecurity/virgil-crypto-c.git",
       "state" : {
-        "revision" : "e386be51ec32aed0391a26925e657b25b2bdbe50",
-        "version" : "0.19.0-rc.12"
+        "revision" : "14942f289394c6819b0547ee20e5dfc26217021f",
+        "version" : "0.19.0-rc.13"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/VirgilSecurity/virgil-crypto-x.git",
       "state" : {
-        "revision" : "c7d4c29164f0cd73d6365b2527cbcbc21a2bdce9",
-        "version" : "7.2.0"
+        "revision" : "42e2648fb7a606f5c349d4a83522577382ae5447",
+        "version" : "7.2.1"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/VirgilSecurity/virgil-sdk-x.git",
       "state" : {
-        "revision" : "30784129508afc537aac14dc934938b467937564",
-        "version" : "9.2.0"
+        "revision" : "8f7e31ca2a0ce20c0b69c7ca13dd9f1e3d26311b",
+        "version" : "9.2.1"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/VirgilSecurity/virgil-crypto-c.git",
       "state" : {
-        "revision" : "14942f289394c6819b0547ee20e5dfc26217021f",
-        "version" : "0.19.0-rc.13"
+        "revision" : "f6a271fd63f63d7e5993ad65ff7b5aad02540cde",
+        "version" : "0.19.0-rc.14"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/VirgilSecurity/virgil-crypto-x.git",
       "state" : {
-        "revision" : "42e2648fb7a606f5c349d4a83522577382ae5447",
-        "version" : "7.2.1"
+        "revision" : "eb9ff065ee8d32a583f3c1789e95365871248c96",
+        "version" : "7.2.2"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/VirgilSecurity/virgil-sdk-x.git",
       "state" : {
-        "revision" : "8f7e31ca2a0ce20c0b69c7ca13dd9f1e3d26311b",
-        "version" : "9.2.1"
+        "revision" : "59b472a3d32ab71aa53af4374c7bd3897a0d14b8",
+        "version" : "9.2.2"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -15,8 +15,8 @@ let package = Package(
     ],
 
     dependencies: [
-        .package(url: "https://github.com/VirgilSecurity/virgil-sdk-x.git", exact: "9.2.1"),
-        .package(url: "https://github.com/VirgilSecurity/virgil-crypto-c.git", exact: "0.19.0-rc.13")
+        .package(url: "https://github.com/VirgilSecurity/virgil-sdk-x.git", exact: "9.2.2"),
+        .package(url: "https://github.com/VirgilSecurity/virgil-crypto-c.git", exact: "0.19.0-rc.14")
     ],
 
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -15,8 +15,8 @@ let package = Package(
     ],
 
     dependencies: [
-        .package(url: "https://github.com/VirgilSecurity/virgil-sdk-x.git", exact: "9.2.0"),
-        .package(url: "https://github.com/VirgilSecurity/virgil-crypto-c.git", exact: "0.19.0-rc.12")
+        .package(url: "https://github.com/VirgilSecurity/virgil-sdk-x.git", exact: "9.2.1"),
+        .package(url: "https://github.com/VirgilSecurity/virgil-crypto-c.git", exact: "0.19.0-rc.13")
     ],
 
     targets: [

--- a/Source/SecureChat/KeysRotation/KeysRotator.swift
+++ b/Source/SecureChat/KeysRotation/KeysRotator.swift
@@ -82,16 +82,17 @@ import VirgilCrypto
     ///   - longTermKeysStorage: long-term keys storage
     ///   - oneTimeKeysStorage: one-time keys storage
     ///   - client: [RatchetClient](x-source-tag://RatchetClient)
-    @objc public init(crypto: VirgilCrypto,
-                      identityPrivateKey: VirgilPrivateKey,
-                      identityCardId: String,
-                      orphanedOneTimeKeyTtl: TimeInterval,
-                      longTermKeyTtl: TimeInterval,
-                      outdatedLongTermKeyTtl: TimeInterval,
-                      desiredNumberOfOneTimeKeys: Int,
-                      longTermKeysStorage: LongTermKeysStorage,
-                      oneTimeKeysStorage: OneTimeKeysStorage,
-                      client: RatchetClientProtocol) {
+    public init(crypto: VirgilCrypto,
+                identityPrivateKey: VirgilPrivateKey,
+                identityCardId: String,
+                orphanedOneTimeKeyTtl: TimeInterval,
+                longTermKeyTtl: TimeInterval,
+                outdatedLongTermKeyTtl: TimeInterval,
+                desiredNumberOfOneTimeKeys: Int,
+                longTermKeysStorage: LongTermKeysStorage,
+                oneTimeKeysStorage: OneTimeKeysStorage,
+                client: RatchetClientProtocol,
+                keyPairType: KeyPairType = .curve25519MlKem768) {
         self.crypto = crypto
         self.identityPrivateKey = identityPrivateKey
         self.identityCardId = identityCardId
@@ -102,9 +103,32 @@ import VirgilCrypto
         self.longTermKeysStorage = longTermKeysStorage
         self.oneTimeKeysStorage = oneTimeKeysStorage
         self.client = client
-        self.keyPairType = .curve25519MlKem768
+        self.keyPairType = keyPairType
 
         super.init()
+    }
+
+    @objc public convenience init(crypto: VirgilCrypto,
+                                  identityPrivateKey: VirgilPrivateKey,
+                                  identityCardId: String,
+                                  orphanedOneTimeKeyTtl: TimeInterval,
+                                  longTermKeyTtl: TimeInterval,
+                                  outdatedLongTermKeyTtl: TimeInterval,
+                                  desiredNumberOfOneTimeKeys: Int,
+                                  longTermKeysStorage: LongTermKeysStorage,
+                                  oneTimeKeysStorage: OneTimeKeysStorage,
+                                  client: RatchetClientProtocol) {
+        self.init(crypto: crypto,
+                  identityPrivateKey: identityPrivateKey,
+                  identityCardId: identityCardId,
+                  orphanedOneTimeKeyTtl: orphanedOneTimeKeyTtl,
+                  longTermKeyTtl: longTermKeyTtl,
+                  outdatedLongTermKeyTtl: outdatedLongTermKeyTtl,
+                  desiredNumberOfOneTimeKeys: desiredNumberOfOneTimeKeys,
+                  longTermKeysStorage: longTermKeysStorage,
+                  oneTimeKeysStorage: oneTimeKeysStorage,
+                  client: client,
+                  keyPairType: .curve25519MlKem768)
     }
 
     /// Rotates keys

--- a/Tests/IntegrationTests.swift
+++ b/Tests/IntegrationTests.swift
@@ -57,8 +57,8 @@ class IntegrationTests: XCTestCase {
         let testConfig = TestConfig.readFromBundle()
         
         let crypto = try! VirgilCrypto()
-        let receiverIdentityKeyPair = try! crypto.generateKeyPair(ofType: .curve25519Ed25519)
-        let senderIdentityKeyPair = try! crypto.generateKeyPair(ofType: .curve25519Ed25519)
+        let receiverIdentityKeyPair = try! crypto.generateKeyPair(ofType: .ed25519)
+        let senderIdentityKeyPair = try! crypto.generateKeyPair(ofType: .ed25519)
         
         let senderIdentity = NSUUID().uuidString
         let receiverIdentity = NSUUID().uuidString

--- a/Tests/IntegrationTests.swift
+++ b/Tests/IntegrationTests.swift
@@ -122,7 +122,7 @@ class IntegrationTests: XCTestCase {
                                           longTermKeysStorage: senderLongTermKeysStorage,
                                           oneTimeKeysStorage: senderOneTimeKeysStorage,
                                           sessionStorage: FileSessionStorage(appGroup: nil, identity: senderIdentity, crypto: crypto, identityKeyPair: senderIdentityKeyPair),
-                                          keysRotator: senderKeysRotator, keyPairType: .curve25519MlKem768)
+                                          keysRotator: senderKeysRotator, keyPairType: .curve25519)
         
         let receiverSecureChat = SecureChat(crypto: crypto,
                                             identityPrivateKey: receiverIdentityKeyPair.privateKey,
@@ -131,7 +131,7 @@ class IntegrationTests: XCTestCase {
                                             longTermKeysStorage: receiverLongTermKeysStorage,
                                             oneTimeKeysStorage: receiverOneTimeKeysStorage,
                                             sessionStorage: FileSessionStorage(appGroup: nil, identity: receiverIdentity, crypto: crypto, identityKeyPair: receiverIdentityKeyPair),
-                                            keysRotator: receiverKeysRotator, keyPairType: .curve25519MlKem768)
+                                            keysRotator: receiverKeysRotator, keyPairType: .curve25519)
         
         return (senderCard, receiverCard, senderSecureChat, receiverSecureChat)
     }

--- a/Tests/IntegrationTests.swift
+++ b/Tests/IntegrationTests.swift
@@ -111,9 +111,9 @@ class IntegrationTests: XCTestCase {
         let receiverClient = RatchetClient(accessTokenProvider: receiverTokenProvider, serviceUrl: URL(string: testConfig.ServiceURL)!)
         let senderClient = RatchetClient(accessTokenProvider: senderTokenProvider, serviceUrl: URL(string: testConfig.ServiceURL)!)
         
-        let receiverKeysRotator = KeysRotator(crypto: crypto, identityPrivateKey: receiverIdentityKeyPair.privateKey, identityCardId: receiverCard.identifier, orphanedOneTimeKeyTtl: 5, longTermKeyTtl: 10, outdatedLongTermKeyTtl: 5, desiredNumberOfOneTimeKeys: IntegrationTests.desiredNumberOfOtKeys, longTermKeysStorage: receiverLongTermKeysStorage, oneTimeKeysStorage: receiverOneTimeKeysStorage, client: receiverClient)
-        
-        let senderKeysRotator = KeysRotator(crypto: crypto, identityPrivateKey: senderIdentityKeyPair.privateKey, identityCardId: senderCard.identifier, orphanedOneTimeKeyTtl: 100, longTermKeyTtl: 100, outdatedLongTermKeyTtl: 100, desiredNumberOfOneTimeKeys: IntegrationTests.desiredNumberOfOtKeys, longTermKeysStorage: senderLongTermKeysStorage, oneTimeKeysStorage: senderOneTimeKeysStorage, client: senderClient)
+        let receiverKeysRotator = KeysRotator(crypto: crypto, identityPrivateKey: receiverIdentityKeyPair.privateKey, identityCardId: receiverCard.identifier, orphanedOneTimeKeyTtl: 5, longTermKeyTtl: 10, outdatedLongTermKeyTtl: 5, desiredNumberOfOneTimeKeys: IntegrationTests.desiredNumberOfOtKeys, longTermKeysStorage: receiverLongTermKeysStorage, oneTimeKeysStorage: receiverOneTimeKeysStorage, client: receiverClient, keyPairType: .curve25519)
+
+        let senderKeysRotator = KeysRotator(crypto: crypto, identityPrivateKey: senderIdentityKeyPair.privateKey, identityCardId: senderCard.identifier, orphanedOneTimeKeyTtl: 100, longTermKeyTtl: 100, outdatedLongTermKeyTtl: 100, desiredNumberOfOneTimeKeys: IntegrationTests.desiredNumberOfOtKeys, longTermKeysStorage: senderLongTermKeysStorage, oneTimeKeysStorage: senderOneTimeKeysStorage, client: senderClient, keyPairType: .curve25519)
         
         let senderSecureChat = SecureChat(crypto: crypto,
                                           identityPrivateKey: senderIdentityKeyPair.privateKey,

--- a/VirgilSDKRatchet.xcodeproj/project.pbxproj
+++ b/VirgilSDKRatchet.xcodeproj/project.pbxproj
@@ -1918,7 +1918,7 @@
 			repositoryURL = "https://github.com/VirgilSecurity/virgil-sdk-x";
 			requirement = {
 				kind = exactVersion;
-				version = 9.1.0;
+				version = 9.2.2;
 			};
 		};
 		F44C27812A82F24400EC1F75 /* XCRemoteSwiftPackageReference "virgil-crypto-c" */ = {
@@ -1926,7 +1926,7 @@
 			repositoryURL = "https://github.com/VirgilSecurity/virgil-crypto-c";
 			requirement = {
 				kind = exactVersion;
-				version = 0.19.0-rc.11;
+				version = 0.19.0-rc.14;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/VirgilSDKRatchet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/VirgilSDKRatchet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/VirgilSecurity/virgil-crypto-c.git",
       "state" : {
-        "revision" : "14942f289394c6819b0547ee20e5dfc26217021f",
-        "version" : "0.19.0-rc.13"
+        "revision" : "f6a271fd63f63d7e5993ad65ff7b5aad02540cde",
+        "version" : "0.19.0-rc.14"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/VirgilSecurity/virgil-crypto-x.git",
       "state" : {
-        "revision" : "42e2648fb7a606f5c349d4a83522577382ae5447",
-        "version" : "7.2.1"
+        "revision" : "eb9ff065ee8d32a583f3c1789e95365871248c96",
+        "version" : "7.2.2"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/VirgilSecurity/virgil-sdk-x",
       "state" : {
-        "revision" : "8f7e31ca2a0ce20c0b69c7ca13dd9f1e3d26311b",
-        "version" : "9.2.1"
+        "revision" : "59b472a3d32ab71aa53af4374c7bd3897a0d14b8",
+        "version" : "9.2.2"
       }
     }
   ],

--- a/VirgilSDKRatchet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/VirgilSDKRatchet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/VirgilSecurity/virgil-crypto-c.git",
       "state" : {
-        "revision" : "e386be51ec32aed0391a26925e657b25b2bdbe50",
-        "version" : "0.19.0-rc.12"
+        "revision" : "14942f289394c6819b0547ee20e5dfc26217021f",
+        "version" : "0.19.0-rc.13"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/VirgilSecurity/virgil-crypto-x.git",
       "state" : {
-        "revision" : "c7d4c29164f0cd73d6365b2527cbcbc21a2bdce9",
-        "version" : "7.2.0"
+        "revision" : "42e2648fb7a606f5c349d4a83522577382ae5447",
+        "version" : "7.2.1"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/VirgilSecurity/virgil-sdk-x",
       "state" : {
-        "revision" : "30784129508afc537aac14dc934938b467937564",
-        "version" : "9.2.0"
+        "revision" : "8f7e31ca2a0ce20c0b69c7ca13dd9f1e3d26311b",
+        "version" : "9.2.1"
       }
     }
   ],


### PR DESCRIPTION
- virgil-crypto-c 0.19.0-rc.12 → 0.19.0-rc.13 (fixes macOS arm64 assertion crash in vscr_ratchet_pb_utils.c)
- virgil-sdk-x 9.2.0 → 9.2.1
- virgil-crypto-x 7.2.0 → 7.2.1 (transitive)
- SPM job: `swift test` re-enabled