### PR TITLE
Add keyPairType to SecureChatContext (tag 0.11.2)

### DIFF
--- a/Source/SecureChat/SecureChat.swift
+++ b/Source/SecureChat/SecureChat.swift
@@ -158,7 +158,8 @@ import VirgilCrypto
                                       desiredNumberOfOneTimeKeys: context.desiredNumberOfOneTimeKeys,
                                       longTermKeysStorage: longTermKeysStorage,
                                       oneTimeKeysStorage: oneTimeKeysStorage,
-                                      client: client)
+                                      client: client,
+                                      keyPairType: context.keyPairType)
 
         self.init(crypto: crypto,
                   identityPrivateKey: context.identityPrivateKey,
@@ -168,7 +169,7 @@ import VirgilCrypto
                   oneTimeKeysStorage: oneTimeKeysStorage,
                   sessionStorage: sessionStorage,
                   keysRotator: keysRotator,
-                  keyPairType: .curve25519MlKem768)
+                  keyPairType: context.keyPairType)
     }
 
     /// Initializer

--- a/Source/SecureChat/SecureChatContext.swift
+++ b/Source/SecureChat/SecureChatContext.swift
@@ -69,6 +69,11 @@ import VirgilSDK
     /// Ratchet client
     @objc public var client: RatchetClient
 
+    /// Key pair type used for long-term and one-time ratchet keys.
+    /// Defaults to .curve25519MlKem768 but must be .curve25519 until the
+    /// PFS server is migrated to accept ML-KEM hybrid keys.
+    public var keyPairType: KeyPairType = .curve25519MlKem768
+
     /// Initializer
     ///
     /// - Parameters:


### PR DESCRIPTION
## Summary

- Adds `keyPairType: KeyPairType = .curve25519MlKem768` to `SecureChatContext` so callers can override the ratchet key type without constructing `SecureChat` from scratch
- Threads `context.keyPairType` through the `SecureChat(context:)` convenience init to both `KeysRotator` and the `SecureChat` designated init (replaces the hardcoded `.curve25519MlKem768`)

This unblocks `virgil-e3kit-x` which needs to pass `.curve25519` until the PFS server is migrated to accept ML-KEM hybrid OTK/LTK keys.

Tagged `0.11.2`.

## Test plan

- [ ] CI: all platforms pass